### PR TITLE
fixed 'nginx: [emerg] unexpected end of parameter' error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,6 @@ ADD nginx.conf 'conf\nginx.conf'
 EXPOSE 10000 10001 10002
 
 ENTRYPOINT C:\entrypoint.cmd
-CMD ["nginx", "-g \"daemon off;\""]
+CMD nginx.exe
 
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -38,3 +38,5 @@ http {
         }
     }
 }
+
+daemon off;


### PR DESCRIPTION
Fixed error: nginx: [emerg] unexpected end of parameter, expecting ";" in command line

as described here: 
https://stackoverflow.com/questions/57627308/docker-image-of-azure-storage-emulator-nginx-error